### PR TITLE
Fix #77 groupmod added (non-unique -o)

### DIFF
--- a/runtime/functions
+++ b/runtime/functions
@@ -19,7 +19,7 @@ map_uidgid() {
   USERMAP_UID=${USERMAP_UID:-$USERMAP_ORIG_UID}
   if [[ ${USERMAP_UID} != ${USERMAP_ORIG_UID} ]] || [[ ${USERMAP_GID} != ${USERMAP_ORIG_GID} ]]; then
     echo "Adapting uid and gid for ${PG_USER}:${PG_USER} to $USERMAP_UID:$USERMAP_GID"
-    groupmod -g ${USERMAP_GID} ${PG_USER}
+    groupmod -o -g ${USERMAP_GID} ${PG_USER}
     sed -i -e "s|:${USERMAP_ORIG_UID}:${USERMAP_GID}:|:${USERMAP_UID}:${USERMAP_GID}:|" /etc/passwd
   fi
 }


### PR DESCRIPTION
```bash
root@f0850703f1e9:/var/lib/postgresql# groupmod --help
Usage: groupmod [options] GROUP

Options:
  -g, --gid GID                 change the group ID to GID
  -h, --help                    display this help message and exit
  -n, --new-name NEW_GROUP      change the name to NEW_GROUP
  -o, --non-unique              allow to use a duplicate (non-unique) GID
  -p, --password PASSWORD       change the password to this (encrypted)
                                PASSWORD
  -R, --root CHROOT_DIR         directory to chroot into


```
option ```-o``` allows groupmod for non-unique id's.

Result:
Before on HOST:
```bash
total 0
drwxr-xr-x  1  102  106  6 Aug 31 11:26 .
d---------+ 1 root root 70 Aug 31 11:37 ..
drwx------  1  102  106  8 Aug 19 15:49 9.5
```

After on HOST:
```bash
total 0
drwxr-xr-x  1 admin users  6 Aug 31 11:38 .
d---------+ 1 root  root  70 Aug 31 11:52 ..
drwx------  1 admin users  8 Aug 19 15:49 9.5
```

Docker log after fix #77
```log
Adapting uid and gid for postgres:postgres to 1024:100
Initializing datadir...
```